### PR TITLE
Add support for parsing variables in the config file

### DIFF
--- a/lib/s3_swf_upload/s3_config.rb
+++ b/lib/s3_swf_upload/s3_config.rb
@@ -8,8 +8,7 @@ module S3SwfUpload
     def self.load_config
       begin
         filename = "#{Rails.root}/config/amazon_s3.yml"
-        file = File.open(filename)
-        config = YAML.load(file)[Rails.env]
+        config = YAML.load(ERB.new(File.read(filename)).result)[Rails.env]
 
         if config == nil
           raise "Could not load config options for #{Rails.env} from #{filename}."


### PR DESCRIPTION
Hey Nathan,

This is my first ever fork so sorry if I've done something wrong!

I use heroku and want to make my apps open source so instead of storing the sensitive s3 data in the amazon_s3.yml file I prefer to do this -

```
production:
  bucket: <%= ENV['S3_BUCKET'] %>
  access_key_id: <%= ENV['S3_KEY'] %>
  secret_access_key: <%= ENV['S3_SECRET'] %>
  max_file_size: <%= ENV['S3_MAX_FILESIZE'].to_i %>
  acl: <%= ENV['S3_ACL'] %>
```

This way I can keep my credentials safe using Heroku's config vars as described on this page http://docs.heroku.com/config-vars

The change I have made doesn't affect the current functionality at all, it just adds this functionality

Thanks,

John
