### PR TITLE
Process amazon_s3.yml with ERB

### DIFF
--- a/lib/s3_swf_upload/s3_config.rb
+++ b/lib/s3_swf_upload/s3_config.rb
@@ -8,8 +8,7 @@ module S3SwfUpload
     def self.load_config
       begin
         filename = "#{Rails.root}/config/amazon_s3.yml"
-        file = File.open(filename)
-        config = YAML.load(file)[Rails.env]
+        config = YAML.load(ERB.new(File.read(filename)).result)[Rails.env]
 
         if config == nil
           raise "Could not load config options for #{Rails.env} from #{filename}."


### PR DESCRIPTION
Hi Nathan,

We're using your fork in a Heroku deployment where we have the S3 credentials as environment variables.  I've put in a change to process the amazon_s3.yml config with ERB so we can get those environment variables into the rest of the plugin.

Anyway, just wanted to offer it up as something you may find useful.

Thanks,

Marc
