### PR TITLE
Fix for #42?

### DIFF
--- a/lib/s3_swf_upload/signature.rb
+++ b/lib/s3_swf_upload/signature.rb
@@ -143,7 +143,7 @@ module S3SwfUpload
       i = 0
       while(i < str.length * $chrsz)
         bin[i>>5] ||= 0
-        bin[i>>5] |= (str[i / $chrsz] & mask) << (32 - $chrsz - i%32)
+        bin[i>>5] |= (str[i / $chrsz].ord & mask) << (32 - $chrsz - i%32)
         i += $chrsz
       end
       return bin


### PR DESCRIPTION
Mask the integer value of a character, rather than the substring. Fixes #42?
