### PR TITLE
Use bundler to handle dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 flex_src/bin-debug
 flex_src/bin-release/s3_upload.swf
 flex_src/html-template
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in fluent-plugin-redis.gemspec
+gemspec

--- a/README.textile
+++ b/README.textile
@@ -19,7 +19,6 @@ h2. Usage
 1. Edit <code>Gemfile</code> and add this as a gem, you'll also need aws-s3
 
 <pre><code>gem 's3_swf_upload', :git => 'git://github.com/nathancolgate/s3-swf-upload-plugin'
-gem 'aws-s3', :require => 'aws/s3'
 </code></pre>
 	
 2. Bundle it!

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
-require 'rubygems'
-require 'rake'
+require 'bundler'
+Bundler::GemHelper.install_tasks
 require 'echoe'
 
 Echoe.new("s3_swf_upload") do |p|

--- a/s3_swf_upload.gemspec
+++ b/s3_swf_upload.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{Rails 3 gem that allows you to upload files directly to S3 from your application using flex for file management, css for presentation, and javascript for behavior.}
 
+  s.add_dependency('aws-s3', '~> 0.6.2')
+
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3


### PR DESCRIPTION
Typically we don't want to manage dependencies of a gem and s3-swf-upload-plugin hasn't used anything to manage them so I added Bundler.
This is also important when you want to release this gem on [rubygems.org](http://rubygems.org).
And now, you don't have to add `gem 'aws-s3'` to your Gemfile anymore!
