### PR TITLE
Prevent variable leakage to global scope from the s3_swf_init function

### DIFF
--- a/lib/s3_swf_upload/railties/generators/uploader/templates/s3_upload.js
+++ b/lib/s3_swf_upload/railties/generators/uploader/templates/s3_upload.js
@@ -14,50 +14,50 @@ var s3_upload_swfobject=function(){var D="undefined",r="object",S="Shockwave Fla
 var s3_swf;
 function s3_swf_init(id, options)
 {
-  buttonWidth      					= (options.buttonWidth != undefined) ? 							options.buttonWidth : 							50;
-  buttonHeight          		= (options.buttonHeight != undefined) ? 						options.buttonHeight : 							50;
-  flashVersion     					= (options.flashVersion != undefined) ? 						options.flashVersion : 							'9.0.0';
-  queueSizeLimit   					= (options.queueSizeLimit != undefined) ? 					options.queueSizeLimit : 						10;
-  fileSizeLimit    					= (options.fileSizeLimit != undefined) ? 						options.fileSizeLimit : 						524288000;
-  fileTypes       					= (options.fileTypes != undefined) ? 								options.fileTypes : 								"*.*";
-  fileTypeDescs   					= (options.fileTypeDescs != undefined) ? 						options.fileTypeDescs : 						"All Files";
-  selectMultipleFiles   		= (options.selectMultipleFiles != undefined) ? 			options.selectMultipleFiles : 			true;
-  keyPrefix        					= (options.keyPrefix != undefined) ? 								options.keyPrefix : 								"";
-	signaturePath							= (options.signaturePath != undefined) ? 						options.signaturePath : 						"s3_uploads.xml";
-  swfFilePath               = (options.swfFilePath != undefined) ?              options.swfFilePath :               "/flash/s3_upload.swf";
-  buttonUpPath							= (options.buttonUpPath != undefined) ? 						options.buttonUpPath : 							"";
-	buttonOverPath						= (options.buttonOverPath != undefined) ? 					options.buttonOverPath : 						"";
-	buttonDownPath						= (options.buttonDownPath != undefined) ? 					options.buttonDownPath : 						"";
+  var buttonWidth      					= (options.buttonWidth != undefined) ? 							options.buttonWidth : 							50;
+  var buttonHeight          		= (options.buttonHeight != undefined) ? 						options.buttonHeight : 							50;
+  var flashVersion     					= (options.flashVersion != undefined) ? 						options.flashVersion : 							'9.0.0';
+  var queueSizeLimit   					= (options.queueSizeLimit != undefined) ? 					options.queueSizeLimit : 						10;
+  var fileSizeLimit    					= (options.fileSizeLimit != undefined) ? 						options.fileSizeLimit : 						524288000;
+  var fileTypes       					= (options.fileTypes != undefined) ? 								options.fileTypes : 								"*.*";
+  var fileTypeDescs   					= (options.fileTypeDescs != undefined) ? 						options.fileTypeDescs : 						"All Files";
+  var selectMultipleFiles   		= (options.selectMultipleFiles != undefined) ? 			options.selectMultipleFiles : 			true;
+  var keyPrefix        					= (options.keyPrefix != undefined) ? 								options.keyPrefix : 								"";
+	var signaturePath							= (options.signaturePath != undefined) ? 						options.signaturePath : 						"s3_uploads.xml";
+  var swfFilePath               = (options.swfFilePath != undefined) ?              options.swfFilePath :               "/flash/s3_upload.swf";
+  var buttonUpPath							= (options.buttonUpPath != undefined) ? 						options.buttonUpPath : 							"";
+	var buttonOverPath						= (options.buttonOverPath != undefined) ? 					options.buttonOverPath : 						"";
+	var buttonDownPath						= (options.buttonDownPath != undefined) ? 					options.buttonDownPath : 						"";
 	                    			
-	onFileAdd									= (options.onFileAdd != undefined) ? 								options.onFileAdd : 								function(file){};
-	onFileRemove							= (options.onFileRemove != undefined) ? 						options.onFileRemove : 							function(file){};
-	onFileSizeLimitReached 		= (options.onFileSizeLimitReached != undefined) ? 	options.onFileSizeLimitReached : 		function(file){};
-	onFileNotInQueue					= (options.onFileNotInQueue != undefined) ? 				options.onFileNotInQueue : 					function(file){};
+	var onFileAdd									= (options.onFileAdd != undefined) ? 								options.onFileAdd : 								function(file){};
+	var onFileRemove							= (options.onFileRemove != undefined) ? 						options.onFileRemove : 							function(file){};
+	var onFileSizeLimitReached 		= (options.onFileSizeLimitReached != undefined) ? 	options.onFileSizeLimitReached : 		function(file){};
+	var onFileNotInQueue					= (options.onFileNotInQueue != undefined) ? 				options.onFileNotInQueue : 					function(file){};
 	                        	                                                                                      	
-	onQueueChange							= (options.onQueueChange != undefined) ? 						options.onQueueChange : 						function(queue){};
-	onQueueClear							= (options.onQueueClear != undefined) ? 						options.onQueueClear : 							function(queue){};
-	onQueueSizeLimitReached		= (options.onQueueSizeLimitReached != undefined) ? 	options.onQueueSizeLimitReached : 	function(queue){};
-	onQueueEmpty							= (options.onQueueEmpty != undefined) ? 						options.onQueueEmpty : 							function(queue){};
+	var onQueueChange							= (options.onQueueChange != undefined) ? 						options.onQueueChange : 						function(queue){};
+	var onQueueClear							= (options.onQueueClear != undefined) ? 						options.onQueueClear : 							function(queue){};
+	var onQueueSizeLimitReached		= (options.onQueueSizeLimitReached != undefined) ? 	options.onQueueSizeLimitReached : 	function(queue){};
+	var onQueueEmpty							= (options.onQueueEmpty != undefined) ? 						options.onQueueEmpty : 							function(queue){};
 	
-	onUploadingStop						= (options.onUploadingStop != undefined) ? 					options.onUploadingStop : 					function(){};
-	onUploadingStart					= (options.onUploadingStart != undefined) ? 				options.onUploadingStart : 					function(){};
-	onUploadingFinish					= (options.onUploadingFinish != undefined) ? 				options.onUploadingFinish : 				function(){};
+	var onUploadingStop						= (options.onUploadingStop != undefined) ? 					options.onUploadingStop : 					function(){};
+	var onUploadingStart					= (options.onUploadingStart != undefined) ? 				options.onUploadingStart : 					function(){};
+	var onUploadingFinish					= (options.onUploadingFinish != undefined) ? 				options.onUploadingFinish : 				function(){};
                           	                                                                                      	
-	onSignatureOpen						= (options.onSignatureOpen != undefined) ? 					options.onSignatureOpen : 					function(file,event){};
-	onSignatureProgress				= (options.onSignatureProgress != undefined) ? 			options.onSignatureProgress : 			function(file,progress_event){};
-	onSignatureHttpStatus			= (options.onSignatureHttpStatus != undefined) ? 		options.onSignatureHttpStatus : 		function(file,http_status_event){};
-	onSignatureComplete				= (options.onSignatureComplete != undefined) ? 			options.onSignatureComplete : 			function(file,event){};
-	onSignatureSecurityError	= (options.onSignatureSecurityError != undefined) ? options.onSignatureSecurityError :	function(file,security_error_event){};
-	onSignatureIOError				= (options.onSignatureIOError != undefined) ? 			options.onSignatureIOError : 				function(file,io_error_event){};
-	onSignatureXMLError				= (options.onSignatureXMLError != undefined) ? 			options.onSignatureXMLError : 			function(file,error_message){};
+	var onSignatureOpen						= (options.onSignatureOpen != undefined) ? 					options.onSignatureOpen : 					function(file,event){};
+	var onSignatureProgress				= (options.onSignatureProgress != undefined) ? 			options.onSignatureProgress : 			function(file,progress_event){};
+	var onSignatureHttpStatus			= (options.onSignatureHttpStatus != undefined) ? 		options.onSignatureHttpStatus : 		function(file,http_status_event){};
+	var onSignatureComplete				= (options.onSignatureComplete != undefined) ? 			options.onSignatureComplete : 			function(file,event){};
+	var onSignatureSecurityError	= (options.onSignatureSecurityError != undefined) ? options.onSignatureSecurityError :	function(file,security_error_event){};
+	var onSignatureIOError				= (options.onSignatureIOError != undefined) ? 			options.onSignatureIOError : 				function(file,io_error_event){};
+	var onSignatureXMLError				= (options.onSignatureXMLError != undefined) ? 			options.onSignatureXMLError : 			function(file,error_message){};
 	                        	                                                                                      	
-	onUploadOpen							= (options.onUploadOpen != undefined) ? 						options.onUploadOpen : 							function(upload_options,event){};
-	onUploadProgress					= (options.onUploadProgress != undefined) ? 				options.onUploadProgress : 					function(upload_options,progress_event){};
-	onUploadHttpStatus				= (options.onUploadHttpStatus != undefined) ? 			options.onUploadHttpStatus : 				function(upload_options,http_status_event){};
-	onUploadComplete					= (options.onUploadComplete != undefined) ? 				options.onUploadComplete : 					function(upload_options,event){};
-	onUploadIOError						= (options.onUploadIOError != undefined) ? 					options.onUploadIOError : 					function(upload_options,io_error_event){};
-	onUploadSecurityError			= (options.onUploadSecurityError != undefined) ? 		options.onUploadSecurityError : 		function(upload_options,security_error_event){};
-	onUploadError							= (options.onUploadError != undefined) ? 						options.onUploadError : 						function(upload_options,error){};
+	var onUploadOpen							= (options.onUploadOpen != undefined) ? 						options.onUploadOpen : 							function(upload_options,event){};
+	var onUploadProgress					= (options.onUploadProgress != undefined) ? 				options.onUploadProgress : 					function(upload_options,progress_event){};
+	var onUploadHttpStatus				= (options.onUploadHttpStatus != undefined) ? 			options.onUploadHttpStatus : 				function(upload_options,http_status_event){};
+	var onUploadComplete					= (options.onUploadComplete != undefined) ? 				options.onUploadComplete : 					function(upload_options,event){};
+	var onUploadIOError						= (options.onUploadIOError != undefined) ? 					options.onUploadIOError : 					function(upload_options,io_error_event){};
+	var onUploadSecurityError			= (options.onUploadSecurityError != undefined) ? 		options.onUploadSecurityError : 		function(upload_options,security_error_event){};
+	var onUploadError							= (options.onUploadError != undefined) ? 						options.onUploadError : 						function(upload_options,error){};
   
   var flashvars = {"s3_swf_obj": (options.swfVarObj != undefined ? options.swfVarObj : 's3_swf')}; //fallback to the global var incase script is used outside of view helper
   var params = {};
@@ -68,10 +68,10 @@ function s3_swf_init(id, options)
 
   s3_upload_swfobject.embedSWF(swfFilePath+"?t=" + new Date().getTime(), id, buttonWidth, buttonHeight, flashVersion, false, flashvars, params, attributes);
  
-  signatureUrl = window.location.protocol + '//' + window.location.host + signaturePath;
-  buttonUpUrl = window.location.protocol + '//' + window.location.host + buttonUpPath;
-  buttonDownUrl = window.location.protocol + '//' + window.location.host + buttonDownPath;
-  buttonOverUrl = window.location.protocol + '//' + window.location.host + buttonOverPath;
+  var signatureUrl = window.location.protocol + '//' + window.location.host + signaturePath;
+  var buttonUpUrl = window.location.protocol + '//' + window.location.host + buttonUpPath;
+  var buttonDownUrl = window.location.protocol + '//' + window.location.host + buttonDownPath;
+  var buttonOverUrl = window.location.protocol + '//' + window.location.host + buttonOverPath;
 
   s3_swf = {
     obj: function() { return document[id]; },


### PR DESCRIPTION
I noticed this problem when I had multiple uploaders on the same page. Essentially the configuration for the second uploader influenced the first uploader because the variables were overwritten. 

This commit fixes that and makes sure the variables do not leak to the global scope.

I did not make any changes to whitespace (if you want, I can clean it up and change tabs into spaces), just added the var's.
