### PR TITLE
Removed aws-s3 from gemspec and README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -16,7 +16,7 @@ There is also a demo app running on heroku at "http://s3swfuploader.heroku.com/"
 
 h2. Usage
 
-1. Edit <code>Gemfile</code> and add this as a gem, you'll also need aws-s3
+1. Edit <code>Gemfile</code> and add this as a gem
 
 <pre><code>gem 's3_swf_upload', :git => 'git://github.com/nathancolgate/s3-swf-upload-plugin'
 </code></pre>

--- a/s3_swf_upload.gemspec
+++ b/s3_swf_upload.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ["--line-numbers", "--inline-source", "--title", "S3_swf_upload", "--main", "README.textile"]
   s.require_paths = ["lib"]
 
-  s.add_dependency('aws-s3', '~> 0.6.2')
-
   if s.respond_to? :specification_version
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3


### PR DESCRIPTION
Hi @nathancolgate,

This will fix ticket #56, thanks to @yuki24 for confirming that aws-s3 is no more required and suggesting to remove you’ll also need aws-s3 in README as well.

Sorry @yuki24 for taking too long to send this pull request.

Regards,
Lalit K. Shandilya
