### PR TITLE
added option to configure aws key and secret via ENV

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -34,6 +34,7 @@ h2. Usage
 If you are using Rails 3.1, you will need to move the generated s3_upload.js from the public/javascripts directory to the app/assets/javascripts directory.
 	
 4. Configure your amazon parameters via the generated <code>config/amazon_s3.yml</code> file.
+(key and secret can optionally be removed from that file and configured via <code>ENV['AWS_ACCESS_KEY_ID']</code> and <code>ENV['AWS_SECRET_ACCESS_KEY']</code>)
 
 5. Make the bucket
 

--- a/lib/s3_swf_upload/s3_config.rb
+++ b/lib/s3_swf_upload/s3_config.rb
@@ -18,8 +18,8 @@ module S3SwfUpload
           raise "Could not load config options for #{Rails.env} from #{filename}."
         end
 
-        @@access_key_id     = config['access_key_id']
-        @@secret_access_key = config['secret_access_key']
+        @@access_key_id     = config['access_key_id'] || ENV['AWS_ACCESS_KEY_ID']
+        @@secret_access_key = config['secret_access_key'] || ENV['AWS_SECRET_ACCESS_KEY']
         @@bucket            = config['bucket']
         @@max_file_size     = config['max_file_size']
         @@acl               = config['acl'] || 'private'


### PR DESCRIPTION
Especially for deployment on heroku this is a nice way of not having your key and secret in the repository. 
