### PR TITLE
Add in content length condition to controller template

### DIFF
--- a/lib/s3_swf_upload/railties/generators/uploader/templates/s3_uploads_controller.rb
+++ b/lib/s3_swf_upload/railties/generators/uploader/templates/s3_uploads_controller.rb
@@ -29,7 +29,7 @@ class S3UploadsController < ApplicationController
         {'acl': '#{acl}'},
         {'Content-Type': '#{content_type}'},
         {'Content-Disposition': 'attachment'},
-        ['content-length-range', 1, #{max_file_size}]
+        ['content-length-range', 1, #{max_file_size}],
         ['starts-with', '$Filename', ''],
         ['eq', '$success_action_status', '201']
     ]

--- a/lib/s3_swf_upload/railties/generators/uploader/templates/s3_uploads_controller.rb
+++ b/lib/s3_swf_upload/railties/generators/uploader/templates/s3_uploads_controller.rb
@@ -13,6 +13,7 @@ class S3UploadsController < ApplicationController
     access_key_id   = S3SwfUpload::S3Config.access_key_id
     acl             = S3SwfUpload::S3Config.acl
     secret_key      = S3SwfUpload::S3Config.secret_access_key
+    max_file_size   = S3SwfUpload::S3Config.max_file_size
     key             = params[:key]
     content_type    = params[:content_type]
     https           = 'false'
@@ -28,6 +29,7 @@ class S3UploadsController < ApplicationController
         {'acl': '#{acl}'},
         {'Content-Type': '#{content_type}'},
         {'Content-Disposition': 'attachment'},
+        ['content-length-range', 1, #{max_file_size}]
         ['starts-with', '$Filename', ''],
         ['eq', '$success_action_status', '201']
     ]

--- a/lib/s3_swf_upload/s3_config.rb
+++ b/lib/s3_swf_upload/s3_config.rb
@@ -21,7 +21,7 @@ module S3SwfUpload
         @@access_key_id     = config['access_key_id'] || ENV['AWS_ACCESS_KEY_ID']
         @@secret_access_key = config['secret_access_key'] || ENV['AWS_SECRET_ACCESS_KEY']
         @@bucket            = config['bucket']
-        @@max_file_size     = config['max_file_size']
+        @@max_file_size     = config['max_file_size'] || 5000000000 
         @@acl               = config['acl'] || 'private'
 
         


### PR DESCRIPTION
This fixes the issue where specifying a max file size in amazon_s3.yml had no practical use. It also prevents malicious users from being able to upload huge files to S3. 
